### PR TITLE
README: Swap naming and links Tardigrade by Storj DCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Velero plugin for Tardigrade
+# Velero plugin for Storj DCS
 
 Velero is a tool to backup Kubernetes clusters. Velero does two things:
 
@@ -7,20 +7,19 @@ Velero is a tool to backup Kubernetes clusters. Velero does two things:
 
 Velero is able to integrate with a variety of storage systems plugins. There are two types of plugins available: object store or volume snapshotter (or both).
 
-Here we implement a Velero Object Store plugin that is backed by Tardigrade object storage.
+Here we implement a Velero Object Store plugin that is backed by Storj DCS object storage.
 
 ## Installation
 
 ### Prerequisites
 
 - Complete Velero prerequisites and install the CLI: [docs](https://velero.io/docs/master/basic-install/)
-- Create a Tardigrade account: [docs](https://tardigrade.io/signup/)
-- Create a project in the Tardigrade account: [docs](https://documentation.tardigrade.io/getting-started/uploading-your-first-object/create-a-project)
-- Create an API key for the project: [docs](https://documentation.tardigrade.io/getting-started/uploading-your-first-object/create-an-api-key)
-- Setup the Uplink CLI and create an access grant for the project: [docs](https://documentation.tardigrade.io/getting-started/uploading-your-first-object/set-up-uplink-cli)
-- Create a Tardigrade bucket where Velero will store the backups: [docs](https://documentation.tardigrade.io/getting-started/uploading-your-first-object/create-a-bucket)
+- Create a Storj DCS account: [docs](https://docs.storj.io/dcs/getting-started/quickstart-uplink-cli/uploading-your-first-object/prerequisites)
+- Create an Access Grant: [docs](https://docs.storj.io/dcs/getting-started/quickstart-uplink-cli/uploading-your-first-object/create-first-access-grant)
+- Set up Uplink CLI with the previously created Access Grant: [doc](https://docs.storj.io/dcs/getting-started/quickstart-uplink-cli/uploading-your-first-object/set-up-uplink-cli)
+- Create a bucket where Velero will store the backups: [docs](https://docs.storj.io/dcs/getting-started/quickstart-uplink-cli/uploading-your-first-object/create-a-bucket)
 
-### Install the Velero plugin for Tardigrade
+### Install the Velero plugin for Tardigrade (a.k.a. Storj DCS)
 
 ```
 $ velero install --provider tardigrade \


### PR DESCRIPTION
The README was not updated after we rebrand Tardigrade to Storj DCS.

This commit only does the README update but it doesn't make any change
in the reference, identifiers, etc. in the sources nor the plugin name
from Tardigrade to Storj DCS.