### PR TITLE
README: Swap naming and links Tardigrade by Storj DCS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,8 @@ pipeline {
     agent {
         docker {
             label 'main'
-            image docker.build("storj-ci", "--pull https://github.com/storj/ci.git").id
+            image 'storjlabs/ci:latest'
+            alwaysPull true
             args '-u root:root --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
         }
     }


### PR DESCRIPTION
The README was not update after we rebrand Tardigrade to Storj DCS.

This commit only does the README update but it doesn't make any change
in the reference, identifiers, etc. in the sources nor the plugin name
from Tardigrade to Storj DCS.